### PR TITLE
fix: Index preferred_label (skos:prefLabel) for search

### DIFF
--- a/folio/graph.py
+++ b/folio/graph.py
@@ -756,6 +756,13 @@ class FOLIO:
             else:
                 self.label_to_index[owl_class.label].append(index)
 
+        # update the alt label index with preferred label
+        if owl_class.preferred_label:
+            if owl_class.preferred_label not in self.alt_label_to_index:
+                self.alt_label_to_index[owl_class.preferred_label] = [index]
+            else:
+                self.alt_label_to_index[owl_class.preferred_label].append(index)
+
         # update the label index with alt labels
         for alt_label in owl_class.alternative_labels:  # pylint: disable=not-an-iterable
             if alt_label:
@@ -877,6 +884,13 @@ class FOLIO:
                 self.property_label_to_index[owl_property.label] = [index]
             else:
                 self.property_label_to_index[owl_property.label].append(index)
+
+        # update the property label index with preferred label
+        if owl_property.preferred_label:
+            if owl_property.preferred_label not in self.property_label_to_index:
+                self.property_label_to_index[owl_property.preferred_label] = [index]
+            else:
+                self.property_label_to_index[owl_property.preferred_label].append(index)
 
             # Add an edge triple for every domain/range pair to support graph traversal
             for domain in owl_property.domain:


### PR DESCRIPTION
## Summary
- Add `preferred_label` to `alt_label_to_index` during class parsing so prefLabels are included in the marisa-trie and found by `search_by_prefix()` and `search_by_label()`
- Add `preferred_label` to `property_label_to_index` during property parsing
- Previously, `preferred_label` was parsed and stored but never indexed, making entities unfindable by their canonical name (e.g., searching "School" did not find "Education - Real Estate Asset")

## Test plan
- [x] All 38 existing tests pass
- [x] Verified `search_by_prefix("School")` now returns "Education - Real Estate Asset"
- [x] Verified `search_by_prefix("Education")` still works (no regression)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: read-only index change at parse time, no runtime behavior change beyond returning more complete search results.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)