### PR TITLE
fix: Include lang-tagged altLabels in search index

### DIFF
--- a/folio/graph.py
+++ b/folio/graph.py
@@ -659,8 +659,8 @@ class FOLIO:
                 lang = child.attrib.get(self.get_ns_tag("xml", "lang"), None)
                 if lang:
                     owl_class.translations[lang] = child.text
-                else:
-                    owl_class.alternative_labels.append(child.text)
+                # Always add to alternative_labels for search indexing
+                owl_class.alternative_labels.append(child.text)
 
                 # add triple
                 self.triples.append((owl_class.iri, "skos:altLabel", child.text))

--- a/folio/graph.py
+++ b/folio/graph.py
@@ -660,7 +660,8 @@ class FOLIO:
                 if lang:
                     owl_class.translations[lang] = child.text
                 # Always add to alternative_labels for search indexing
-                owl_class.alternative_labels.append(child.text)
+                if child.text not in owl_class.alternative_labels:
+                    owl_class.alternative_labels.append(child.text)
 
                 # add triple
                 self.triples.append((owl_class.iri, "skos:altLabel", child.text))


### PR DESCRIPTION
## Summary
- **Bug**: `altLabels` with `xml:lang` attribute (90% of all altLabels — 52,238 of 57,510) were added to `translations` but excluded from `alternative_labels`, making them invisible to `search_by_label()`.
- **Fix**: Always append to `alternative_labels` regardless of language tag, so e.g. searching "Patent Prosecution" correctly matches "Patent Registration Process" (which has `altLabel` "Patent Prosecution" with `xml:lang="en-us"`).

## Test plan
- [ ] `python -m pytest` — all 38 tests pass
- [ ] Verify: `FOLIO().search_by_label("Patent Prosecution", include_alt_labels=True)` returns "Patent Registration Process" with score 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)